### PR TITLE
Dockerize MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+.venv
+.env.example
+__pycache__
+examples/
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ COPY . .
 
 # Install dependencies
 RUN pip install --no-cache-dir uv --upgrade \
-    && uv sync \
-    && pip install --no-cache-dir .
+    && uv sync
 
 # Default command
 CMD ["uv","run","python","-m","opentargets_mcp.server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ FROM python:3.12-slim
 WORKDIR /app
 
 # Copy requirements / project
-COPY pyproject.toml .
 COPY . .
 
 # Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # Use a suitable Python base image
 FROM python:3.12-slim
 
-# Set workdir
-WORKDIR /app
-
 # Copy requirements / project
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use a suitable Python base image
+FROM python:3.12-slim
+
+# Set workdir
+WORKDIR /app
+
+# Copy requirements / project
+COPY pyproject.toml .
+COPY . .
+
+# Install dependencies
+RUN pip install --no-cache-dir uv --upgrade \
+    && uv sync \
+    && pip install --no-cache-dir .
+
+# Default command
+CMD ["uv","run","python","-m","opentargets_mcp.server"]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ mcpm import stdio opentargets \
 
 Then restart Claude Desktop to start using the Open Targets tools.
 
+
+
 ### For Other MCP Clients
+
+#### Option 1: Manual Setup
 ```bash
 git clone https://github.com/nickzren/opentargets-mcp
 cd opentargets-mcp
@@ -54,6 +58,14 @@ uv sync
 
 # Option 2: Run directly
 uv run python -m opentargets_mcp.server
+```
+#### Option 2: Using Docker
+```bash
+git clone https://github.com/nickzren/opentargets-mcp
+cd opentargets-mcp
+
+# Build and run with Docker Compose
+docker-compose up -d --build
 ```
 
 ## Features
@@ -135,7 +147,7 @@ uv run python -m opentargets_mcp.server --transport [stdio|sse|http]
 
 ### Configuration
 
-- **Environment variables**: `MCP_TRANSPORT` (`stdio`, `sse`, or `http`), `FASTMCP_SERVER_HOST`, and `FASTMCP_SERVER_PORT` control the transport and bind address. Defaults are `stdio`, `0.0.0.0`, and `8000`.
+- **Environment variables**: `MCP_TRANSPORT` (`stdio`, `sse`, or `http`), `FASTMCP_SERVER_HOST`, and `FASTMCP_SERVER_PORT` control the transport and bind address. Defaults are `stdio`, `0.0.0.0`, and `8000`. `OPEN_TARGETS_API_URL` can be set to use a custom Open Targets API endpoint.
 - **Command line**: `opentargets-mcp --transport [stdio|sse|http] --host 0.0.0.0 --port 8000` provides flexible transport selection.
 - **Verbose logging**: add `--verbose` to elevate the global log level to DEBUG when troubleshooting.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ cd opentargets-mcp
 # Build and run with Docker Compose
 docker-compose up -d --build
 ```
+Note: the default transport is `http` for docker deployments.
+
+See the configuration section below for details and how to set ports and other environment variables.
 
 ## Features
 
@@ -147,7 +150,7 @@ uv run python -m opentargets_mcp.server --transport [stdio|sse|http]
 
 ### Configuration
 
-- **Environment variables**: `MCP_TRANSPORT` (`stdio`, `sse`, or `http`), `FASTMCP_SERVER_HOST`, and `FASTMCP_SERVER_PORT` control the transport and bind address. Defaults are `stdio`, `0.0.0.0`, and `8000`. `OPEN_TARGETS_API_URL` can be set to use a custom Open Targets API endpoint.
+- **Environment variables**: `MCP_TRANSPORT` (`stdio`, `sse`, or `http`), `FASTMCP_SERVER_HOST`, and `FASTMCP_SERVER_PORT` control the transport and bind address. Defaults are `stdio`, `0.0.0.0`, and `8000`. `OPEN_TARGETS_API_URL` can be set to use a custom Open Targets API endpoint. Default is set to the public API: `https://api.platform.opentargets.org/api/v4/graphql`.
 - **Command line**: `opentargets-mcp --transport [stdio|sse|http] --host 0.0.0.0 --port 8000` provides flexible transport selection.
 - **Verbose logging**: add `--verbose` to elevate the global log level to DEBUG when troubleshooting.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  ot-mcp-server:
+    container_name: ot-mcp-server
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/app
+    restart: unless-stopped
+    command: ["uv", "run", "python", "-m", "opentargets_mcp.server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8000:8000"
+      - "${FASTMCP_SERVER_PORT:-8000}:${FASTMCP_SERVER_PORT:-8000}"
     volumes:
       - .:/app
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    environment:
+      - .env
     ports:
       - "${FASTMCP_SERVER_PORT:-8000}:${FASTMCP_SERVER_PORT:-8000}"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,5 @@ services:
       - .env
     ports:
       - "${FASTMCP_SERVER_PORT:-8000}:${FASTMCP_SERVER_PORT:-8000}"
-    volumes:
-      - .:/app
     restart: unless-stopped
     command: ["uv", "run", "python", "-m", "opentargets_mcp.server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,10 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
-      - .env
+      - FASTMCP_SERVER_HOST=${FASTMCP_SERVER_HOST:-0.0.0.0}
+      - FASTMCP_SERVER_PORT=${FASTMCP_SERVER_PORT:-8000}
+      - MCP_TRANSPORT=${MCP_TRANSPORT:-http}
+      - OPEN_TARGETS_API_URL=${OPEN_TARGETS_API_URL:-https://api.platform.opentargets.org/api/v4/graphql}
     ports:
       - "${FASTMCP_SERVER_PORT:-8000}:${FASTMCP_SERVER_PORT:-8000}"
     restart: unless-stopped

--- a/src/opentargets_mcp/server.py
+++ b/src/opentargets_mcp/server.py
@@ -61,7 +61,13 @@ async def lifespan(server: FastMCP):
     global _client
 
     logger.info("Starting Open Targets MCP server")
-    _client = OpenTargetsClient()
+    api_url = os.getenv("OPEN_TARGETS_API_URL")
+    if api_url is not None:
+        logger.info("Using custom Open Targets API URL: %s", api_url)
+        _client = OpenTargetsClient(base_url=api_url)
+    else:
+        logger.info("Using default Open Targets API URL")
+        _client = OpenTargetsClient()
     await _client._ensure_session()
 
     try:
@@ -80,6 +86,7 @@ mcp = FastMCP(
     name="opentargets",
     version="0.2.0",
     lifespan=lifespan,
+    stateless_http=True,
 )
 
 _target_api = TargetApi()

--- a/src/opentargets_mcp/server.py
+++ b/src/opentargets_mcp/server.py
@@ -63,10 +63,8 @@ async def lifespan(server: FastMCP):
     logger.info("Starting Open Targets MCP server")
     api_url = os.getenv("OPEN_TARGETS_API_URL")
     if api_url is not None:
-        logger.info("Using custom Open Targets API URL: %s", api_url)
         _client = OpenTargetsClient(base_url=api_url)
     else:
-        logger.info("Using default Open Targets API URL")
         _client = OpenTargetsClient()
     await _client._ensure_session()
 
@@ -295,6 +293,12 @@ def main() -> None:
         args.host,
         args.port,
     )
+
+    api_url = os.getenv("OPEN_TARGETS_API_URL")
+    if api_url is not None:
+        logger.info("Using Open Targets API URL: %s", api_url)
+    else:
+        logger.info("Using default Open Targets API URL")
 
     try:
         if args.transport == "http":

--- a/src/opentargets_mcp/server.py
+++ b/src/opentargets_mcp/server.py
@@ -86,7 +86,6 @@ mcp = FastMCP(
     name="opentargets",
     version="0.2.0",
     lifespan=lifespan,
-    stateless_http=True,
 )
 
 _target_api = TargetApi()


### PR DESCRIPTION
The mcp server can now easily be run using docker. 

Moreover, a custom OpenTargets API url can be set.